### PR TITLE
Fix defeat screen statistics button

### DIFF
--- a/src/handlers/ui-handler.js
+++ b/src/handlers/ui-handler.js
@@ -193,7 +193,7 @@ export function handleUIAction(state, action) {
     return { ...state, phase: 'quests', previousPhase: state.phase };
   }
 
-  if (type === 'VIEW_STATS') {
+  if (type === 'VIEW_STATS' || type === 'SHOW_STATS') {
     if (isPreAdventure) return null;
     return { ...state, phase: 'stats', previousPhase: state.phase };
   }

--- a/src/render.js
+++ b/src/render.js
@@ -1273,7 +1273,7 @@ export function render(state, dispatch) {
     document.getElementById('btnLoad').onclick = () => dispatch({ type: 'LOAD' });
     const btnViewStats = document.getElementById('btnViewStats');
     if (btnViewStats) {
-      btnViewStats.onclick = () => dispatch({ type: 'SHOW_STATS' });
+      btnViewStats.onclick = () => dispatch({ type: 'VIEW_STATS' });
     }
 
     log.innerHTML = state.log

--- a/tests/character-sheet-ui-regression-test.mjs
+++ b/tests/character-sheet-ui-regression-test.mjs
@@ -65,3 +65,22 @@ test('render source wires character labels, character-sheet content, and talents
     'opening talents should reset viewport to top',
   );
 });
+
+
+test('SHOW_STATS alias still opens the character sheet phase from defeat', () => {
+  const state = createBaseState({ phase: 'defeat' });
+  const next = handleUIAction(state, { type: 'SHOW_STATS' });
+
+  assert.ok(next);
+  assert.equal(next.phase, 'stats');
+  assert.equal(next.previousPhase, 'defeat');
+});
+
+test('defeat screen View Statistics button dispatches VIEW_STATS', () => {
+  const src = readFileSync('src/render.js', 'utf8');
+  assert.match(
+    src,
+    /btnViewStats\.onclick = \(\) => dispatch\(\{ type: 'VIEW_STATS' \}\)/,
+    'defeat screen stats button should dispatch VIEW_STATS so the button works in-browser',
+  );
+});


### PR DESCRIPTION
## Summary
- fix the defeat screen View Statistics button to dispatch the existing VIEW_STATS action
- accept SHOW_STATS as a compatibility alias in the UI handler
- add a regression test covering the defeat-screen stats action wiring

## Testing
- node --test tests/character-sheet-ui-regression-test.mjs