### PR TITLE
Show latest grouped combat log turns first

### DIFF
--- a/src/battle-log-ui.js
+++ b/src/battle-log-ui.js
@@ -142,8 +142,8 @@ export function renderBattleLogPanel(entries, maxVisibleOrOptions = 40) {
 
   let content = '';
   if (grouped) {
-    const groupedEntries = groupEntriesByTurn(limited);
-    content = [...groupedEntries.entries()].map(([turn, turnEntries]) => `
+    const groupedEntries = [...groupEntriesByTurn(limited).entries()].sort((a, b) => b[0] - a[0]);
+    content = groupedEntries.map(([turn, turnEntries]) => `
       <details class="bl-turn-group" open>
         <summary class="bl-turn-summary">Turn ${turn} · ${turnEntries.length}</summary>
         <div class="bl-turn-entries">

--- a/tests/battle-log-test.mjs
+++ b/tests/battle-log-test.mjs
@@ -229,6 +229,22 @@ test('renderBattleLogPanel with grouped option uses details elements', () => {
   assert.match(html, /bl-turn-group/);
 });
 
+test('renderBattleLogPanel with grouped option shows latest turn first', () => {
+  const log = new BattleLog();
+  log.startTurn(1);
+  log.addEntry('attack', 'Turn 1 action');
+  log.startTurn(2);
+  log.addEntry('attack', 'Turn 2 action');
+
+  const html = renderBattleLogPanel(log.entries, { grouped: true });
+  const turn2Index = html.indexOf('Turn 2 ·');
+  const turn1Index = html.indexOf('Turn 1 ·');
+
+  assert.ok(turn2Index >= 0);
+  assert.ok(turn1Index >= 0);
+  assert.ok(turn2Index < turn1Index);
+});
+
 test('renderBattleLogPanel with showSummary=true shows damage summary when damage exists', () => {
   const log = new BattleLog();
   log.startTurn(1);


### PR DESCRIPTION
## Summary\n- render grouped combat-log turns newest-first instead of oldest-first\n- keep the latest combat events visible without manual scrolling in typical encounters\n- add a regression test covering grouped turn ordering\n\n## Why\nBrowser QA showed that after actions like failed flee, the combat log header/chips updated to the latest turn but the visible viewport still showed old turn-1 entries at the top. Because grouped turns were rendered in ascending order inside a fixed-height scroll box, important newest feedback was hidden by default, making combat actions feel silent.\n\n## Testing\n- TAP version 13
# Subtest: addEntry stores entries with timestamp and turn context
ok 1 - addEntry stores entries with timestamp and turn context
  ---
  duration_ms: 2.203323
  type: 'test'
  ...
# Subtest: addEntry defaults details to null when omitted
ok 2 - addEntry defaults details to null when omitted
  ---
  duration_ms: 0.340798
  type: 'test'
  ...
# Subtest: startTurn increments when no turn number is provided
ok 3 - startTurn increments when no turn number is provided
  ---
  duration_ms: 0.374582
  type: 'test'
  ...
# Subtest: startTurn respects explicit turn number
ok 4 - startTurn respects explicit turn number
  ---
  duration_ms: 0.227283
  type: 'test'
  ...
# Subtest: endTurn records a turn-end entry for the current turn
ok 5 - endTurn records a turn-end entry for the current turn
  ---
  duration_ms: 0.490254
  type: 'test'
  ...
# Subtest: getCombatSummary totals damage, received damage, and healing
ok 6 - getCombatSummary totals damage, received damage, and healing
  ---
  duration_ms: 0.63111
  type: 'test'
  ...
# Subtest: getCombatSummary counts damaging ability entries toward damage dealt
ok 7 - getCombatSummary counts damaging ability entries toward damage dealt
  ---
  duration_ms: 1.564728
  type: 'test'
  ...
# Subtest: getCombatSummary tracks status effects uniquely
ok 8 - getCombatSummary tracks status effects uniquely
  ---
  duration_ms: 0.484362
  type: 'test'
  ...
# Subtest: getCombatSummary tracks abilities used uniquely
ok 9 - getCombatSummary tracks abilities used uniquely
  ---
  duration_ms: 0.793991
  type: 'test'
  ...
# Subtest: getCombatSummary tracks items used uniquely
ok 10 - getCombatSummary tracks items used uniquely
  ---
  duration_ms: 0.637343
  type: 'test'
  ...
# Subtest: getCombatSummary derives totalTurns from recorded turns
ok 11 - getCombatSummary derives totalTurns from recorded turns
  ---
  duration_ms: 0.361167
  type: 'test'
  ...
# Subtest: clear resets entries and turn counter
ok 12 - clear resets entries and turn counter
  ---
  duration_ms: 0.18379
  type: 'test'
  ...
# Subtest: invalid entry types throw an error
ok 13 - invalid entry types throw an error
  ---
  duration_ms: 0.599401
  type: 'test'
  ...
# Subtest: singleton battleLog can be used directly
ok 14 - singleton battleLog can be used directly
  ---
  duration_ms: 4.274193
  type: 'test'
  ...
# Subtest: renderBattleLogPanel shows header and turn counter
ok 15 - renderBattleLogPanel shows header and turn counter
  ---
  duration_ms: 36.962901
  type: 'test'
  ...
# Subtest: renderBattleLogPanel limits visible entries based on maxVisible
ok 16 - renderBattleLogPanel limits visible entries based on maxVisible
  ---
  duration_ms: 0.553514
  type: 'test'
  ...
# Subtest: renderBattleLogPanel escapes HTML in messages
ok 17 - renderBattleLogPanel escapes HTML in messages
  ---
  duration_ms: 0.233134
  type: 'test'
  ...
# Subtest: getBattleLogStyles exposes panel styling
ok 18 - getBattleLogStyles exposes panel styling
  ---
  duration_ms: 0.243783
  type: 'test'
  ...
# Subtest: getEntriesByTurn groups entries correctly
ok 19 - getEntriesByTurn groups entries correctly
  ---
  duration_ms: 0.261629
  type: 'test'
  ...
# Subtest: filterEntries returns only specified types
ok 20 - filterEntries returns only specified types
  ---
  duration_ms: 0.23625
  type: 'test'
  ...
# Subtest: filterEntries with empty array returns all entries
ok 21 - filterEntries with empty array returns all entries
  ---
  duration_ms: 0.122904
  type: 'test'
  ...
# Subtest: renderBattleLogPanel with grouped option uses details elements
ok 22 - renderBattleLogPanel with grouped option uses details elements
  ---
  duration_ms: 0.519448
  type: 'test'
  ...
# Subtest: renderBattleLogPanel with grouped option shows latest turn first
ok 23 - renderBattleLogPanel with grouped option shows latest turn first
  ---
  duration_ms: 0.28383
  type: 'test'
  ...
# Subtest: renderBattleLogPanel with showSummary=true shows damage summary when damage exists
ok 24 - renderBattleLogPanel with showSummary=true shows damage summary when damage exists
  ---
  duration_ms: 0.187938
  type: 'test'
  ...
# Subtest: renderBattleLogPanel summary includes ability damage in dealt badge
ok 25 - renderBattleLogPanel summary includes ability damage in dealt badge
  ---
  duration_ms: 0.177037
  type: 'test'
  ...
# Subtest: renderBattleLogPanel entries have data-type attribute
ok 26 - renderBattleLogPanel entries have data-type attribute
  ---
  duration_ms: 0.251198
  type: 'test'
  ...
# Subtest: renderBattleLogPanel with activeFilters only shows matching types
ok 27 - renderBattleLogPanel with activeFilters only shows matching types
  ---
  duration_ms: 0.234376
  type: 'test'
  ...
# Subtest: renderFilterBar returns filter pills
ok 28 - renderFilterBar returns filter pills
  ---
  duration_ms: 0.260596
  type: 'test'
  ...
1..28
# tests 28
# suites 0
# pass 28
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 267.034107\n- browser-verified locally on the integrated build: after a failed flee, Turn 2 now appears at the top of the combat log instead of Turn 1